### PR TITLE
Stop reformatting attributes when we made no changes

### DIFF
--- a/src/Converter.cs
+++ b/src/Converter.cs
@@ -88,7 +88,12 @@ namespace mellite {
 			createdAttributes.AddRange (ProcessUnavailable (info));
 			createdAttributes.AddRange (ProcessObsolete (info));
 
-			return member.WithAttributeLists (new SyntaxList<AttributeListSyntax> (GenerateFinalAttributes (info, createdAttributes)));
+			// Only reformat attributes if we're created new attributes or have existing availability attributes wrapped in defines
+			if (createdAttributes.Any () || info.ExistingAvailabilityAttributes.Any ()) {
+				return member.WithAttributeLists (new SyntaxList<AttributeListSyntax> (GenerateFinalAttributes (info, createdAttributes)));
+			} else {
+				return member;
+			}
 		}
 
 		List<AttributeListSyntax> ProcessIntroduced (HarvestedMemberInfo info)

--- a/test/ConverterTests.cs
+++ b/test/ConverterTests.cs
@@ -1191,5 +1191,22 @@ public static class LaunchServices
 #endif
 ");
 		}
+
+		[Fact]
+		public void NetworkHangingDefine ()
+		{
+			TestConversionToSame (@"namespace Network {
+	public class NWTxtRecord : NativeObject {
+#if !XAMCORE_4_0
+		[Obsolete (""Use the overload that takes an NWTxtRecordApplyDelegate2 instead."")]
+#endif
+		[BindingImpl (BindingImplOptions.Optimizable)]
+		public bool Apply (NWTxtRecordApplyDelegate handler)
+		{
+		}
+	}
+}
+");
+		}
 	}
 }


### PR DESCRIPTION
- In some rare cases (mostly with define around attributes) we'd generate broken code
- Detect when there is "no work to do" and skip GenerateFinalAttribute unnecessarily